### PR TITLE
fix issue #26

### DIFF
--- a/kernel/headers/logic/collections/Dictionary.hpp
+++ b/kernel/headers/logic/collections/Dictionary.hpp
@@ -67,7 +67,7 @@ private:
 
     int getNodeIndexByKey(TKey key) {
         for(int i = 0; i < this->_count; i++) {
-            if(this->_elements[i]->key == key) return this->_elements[i];
+            if(this->_elements[i]->key == key) return i;
         }
         return -1;
     }


### PR DESCRIPTION
Dictionary getNodeIndexByKey now returns it's index instead of the element.